### PR TITLE
Update dead links in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,10 @@ regular expressions).
 # Lineage
 
 I got the idea and general implementation strategy from Russ Cox in his
-[article on regexps](https://swtch.com/~rsc/regexp/regexp3.html) and RE2.
+[article on regexps](https://web.archive.org/web/20160404141123/https://swtch.com/~rsc/regexp/regexp3.html) and RE2.
 Russ Cox got it from Ken Thompson's `grep` (no source, folk lore?).
 I also got the idea from
-[Lucene](https://github.com/apache/lucene-solr/blob/trunk/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java),
+[Lucene](https://github.com/apache/lucene-solr/blob/ae93f4e7ac6a3908046391de35d4f50a0d3c59ca/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java),
 which uses it for executing automata on their term index.
 */
 


### PR DESCRIPTION
Latest archive.org version of Russ Cox article and a permalink to the Lucene file as I could find on the master branch just now. 
Tip: GitHub has this keyboard shortcut `y` that changes a relative link (usually includes the branch or tag name) to a permalink using the commit hash :)
