### PR TITLE
rollup + fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rust:
   - beta
   - nightly
 script: ci/script.sh
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,4 @@ rust:
   - stable
   - beta
   - nightly
-script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
+script: ci/script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ license = "Unlicense/MIT"
 travis-ci = { repository = "BurntSushi/utf8-ranges" }
 
 [dev-dependencies]
-quickcheck = "0.5"
+quickcheck = "0.6"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -ex
+
+cargo build --verbose
+cargo doc --verbose
+
+# If we're testing on an older version of Rust, then only check that we
+# can build the crate. This is because the dev dependencies might be updated
+# more frequently, and therefore might require a newer version of Rust.
+#
+# This isn't ideal. It's a compromise.
+if [ "$TRAVIS_RUST_VERSION" = "1.12.0" ]; then
+  exit
+fi
+
+cargo test --verbose


### PR DESCRIPTION
This rolls up #5 and fixes CI such that tests are no longer run on Rust 1.12 (but we still check compilation).