### PR TITLE
Add no_std + alloc support by way of a default "std" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ travis-ci = { repository = "BurntSushi/utf8-ranges" }
 default = ["std"]
 # When disabled, allows use in `no_std` builds with access to a heap by way of alloc
 std = []
+# Required for use in `no_std` builds, and mutually exclusive with "std" feature
+alloc = []
+
 
 [dev-dependencies]
 quickcheck = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,10 @@ license = "Unlicense/MIT"
 [badges]
 travis-ci = { repository = "BurntSushi/utf8-ranges" }
 
+[features]
+default = ["std"]
+# When disabled, allows use in `no_std` builds with access to a heap by way of alloc
+std = []
+
 [dev-dependencies]
 quickcheck = "0.6"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -20,5 +20,5 @@ cargo test --verbose
 # If we have nightly, test no_std mode by removing.
 # the default feature, "std".
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-  cargo test --lib --verbose --no-default-features
+  cargo test --lib --verbose --no-default-features --features "alloc"
 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,4 +14,11 @@ if [ "$TRAVIS_RUST_VERSION" = "1.12.0" ]; then
   exit
 fi
 
+# Run tests.
 cargo test --verbose
+
+# If we have nightly, test no_std mode by removing.
+# the default feature, "std".
+if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  cargo test --lib --verbose --no-default-features
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,15 +85,55 @@ Russ Cox got it from Ken Thompson's `grep` (no source, folk lore?).
 I also got the idea from
 [Lucene](https://github.com/apache/lucene-solr/blob/ae93f4e7ac6a3908046391de35d4f50a0d3c59ca/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java),
 which uses it for executing automata on their term index.
+
+# Use in no_std environments
+
+This library can function in `#![no_std]` environments that have access to
+a heap allocator. To do so, disable the library's default features
+(to remove the on-by-default "std" feature).
+
+Presently using a nightly compiler toolchain is required for this option.
+
+```toml
+[dependencies.utf8-ranges]
+version = "1"
+default-features = false
+features = []
+```
+
 */
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #![deny(missing_docs)]
 
 #[cfg(test)] extern crate quickcheck;
 
+#[cfg(all(test, not(feature = "std")))]
+#[macro_use]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 use std::char;
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(feature = "std")]
 use std::slice;
+
+#[cfg(not(feature = "std"))]
+use core::char;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::slice;
+#[cfg(not(feature = "std"))]
+use alloc::Vec;
+
 
 use char_utf8::encode_utf8;
 
@@ -441,6 +481,8 @@ fn max_scalar_value(nbytes: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use std::char;
+    #[cfg(not(feature = "std"))]
+    use std::vec::Vec;
 
     use quickcheck::{TestResult, quickcheck};
 


### PR DESCRIPTION
## What

The addition of a feature flag, and conditional compilation blocks to make utf8-ranges work in either `std` or `no_std` + `alloc` environments, very much in the same vein as https://github.com/BurntSushi/aho-corasick/pull/28 .

The default-on "std" feature flag controls whether or not to compile in `#![no_std]` mode. As stated in the updated docs, due to the use of the presently-unstable `alloc` API, `no_std` mode only works with a nightly toolchain at present.

## How

To build for `std`, nothing changes. `cargo build`

To build for `no_std`:

```
cargo build --no-default-features --features "alloc"
```

The test suites pass as normal in either mode.

## Why

This PR is part of an effort to get `regex` and its dependencies to operate in `no_std` + `alloc` mode. 

